### PR TITLE
Fix display name fetching

### DIFF
--- a/explorer/src/components/account/DomainsCard.tsx
+++ b/explorer/src/components/account/DomainsCard.tsx
@@ -21,15 +21,14 @@ export function DomainsCard({ pubkey }: { pubkey: PublicKey }) {
   return (
     <div className="card">
       <div className="card-header align-items-center">
-        <h3 className="card-header-title">Domain Names Owned</h3>
+        <h3 className="card-header-title">Owned Domain Names</h3>
       </div>
       <div className="table-responsive mb-0">
         <table className="table table-sm table-nowrap card-table">
           <thead>
             <tr>
-              <th className="text-muted">Domain name</th>
-              <th className="text-muted">Domain Address</th>
-              <th className="text-muted">Domain Class Address</th>
+              <th className="text-muted">Domain Name</th>
+              <th className="text-muted">Name Service Account</th>
             </tr>
           </thead>
           <tbody className="list">
@@ -52,9 +51,6 @@ function RenderDomainRow({ domainInfo }: { domainInfo: DomainInfo }) {
       <td>{domainInfo.name}</td>
       <td>
         <Address pubkey={domainInfo.address} link />
-      </td>
-      <td>
-        <Address pubkey={domainInfo.class} link />
       </td>
     </tr>
   );

--- a/explorer/src/utils/name-service.tsx
+++ b/explorer/src/utils/name-service.tsx
@@ -1,8 +1,5 @@
 import { PublicKey, Connection } from "@solana/web3.js";
 import {
-  getHashedName,
-  getNameAccountKey,
-  NameRegistryState,
   getFilteredProgramAccounts,
   NAME_PROGRAM_ID,
   performReverseLookup,
@@ -10,40 +7,32 @@ import {
 import { useState, useEffect } from "react";
 import { Cluster, useCluster } from "providers/cluster";
 
-// Name auctionning Program ID
-export const PROGRAM_ID = new PublicKey(
-  "jCebN34bUfdeUYJT13J1yG16XWQpt5PDx6Mse9GUqhR"
+// Address of the SOL TLD
+const SOL_TLD_AUTHORITY = new PublicKey(
+  "58PwtjSDuFHuUkYjH9BYnnQKHfwo9reZhC2zMJv9JPkx"
 );
-
 export interface DomainInfo {
   name: string;
   address: PublicKey;
-  class: PublicKey;
 }
 
-async function getDomainKey(
-  name: string,
-  nameClass?: PublicKey,
-  nameParent?: PublicKey
-) {
-  const hashedDomainName = await getHashedName(name);
-  const nameKey = await getNameAccountKey(
-    hashedDomainName,
-    nameClass,
-    nameParent
-  );
-  return nameKey;
-}
-
-export async function findOwnedNameAccountsForUser(
+async function getUserDomainAddresses(
   connection: Connection,
-  userAccount: PublicKey
+  userAddress: PublicKey
 ): Promise<PublicKey[]> {
   const filters = [
+    // parent
+    {
+      memcmp: {
+        offset: 0,
+        bytes: SOL_TLD_AUTHORITY.toBase58(),
+      },
+    },
+    // owner
     {
       memcmp: {
         offset: 32,
-        bytes: userAccount.toBase58(),
+        bytes: userAddress.toBase58(),
       },
     },
   ];
@@ -55,54 +44,8 @@ export async function findOwnedNameAccountsForUser(
   return accounts.map((a) => a.publicKey);
 }
 
-async function getDomainInfo(
-  nameAccount: PublicKey,
-  centralState: PublicKey,
-  connection: Connection
-) {
-  const domainKey = await getDomainKey(nameAccount.toBase58(), centralState);
-  let nameRegistry;
-  try {
-    const nameRegistryState = await NameRegistryState.retrieve(
-      connection,
-      domainKey
-    );
-    nameRegistry = nameRegistryState.registry;
-  } catch {}
-
-  if (!nameRegistry?.data) {
-    return;
-  }
-
-  const name = await performReverseLookup(connection, nameAccount);
-
-  return {
-    name: name + ".sol",
-    address: domainKey,
-    class: nameRegistry.class,
-  };
-}
-
-async function getMultipleDomainsInfo(
-  connection: Connection,
-  nameAccounts: PublicKey[]
-): Promise<DomainInfo[]> {
-  let [centralState] = await PublicKey.findProgramAddress(
-    [PROGRAM_ID.toBuffer()],
-    PROGRAM_ID
-  );
-
-  const domainData = await Promise.all(
-    nameAccounts.map((nameAccount) =>
-      getDomainInfo(nameAccount, centralState, connection)
-    )
-  );
-
-  return domainData.filter((e) => !!e) as DomainInfo[];
-}
-
 export const useUserDomains = (
-  address: PublicKey
+  userAddress: PublicKey
 ): [DomainInfo[] | null, boolean] => {
   const { url, cluster } = useCluster();
   const [result, setResult] = useState<DomainInfo[] | null>(null);
@@ -115,12 +58,21 @@ export const useUserDomains = (
       const connection = new Connection(url, "confirmed");
       try {
         setLoading(true);
-        const domains = await findOwnedNameAccountsForUser(connection, address);
-        let names = await getMultipleDomainsInfo(connection, domains);
-        names.sort((a, b) => {
-          return a.name.localeCompare(b.name);
-        });
-        setResult(names);
+        const userDomainAddresses = await getUserDomainAddresses(
+          connection,
+          userAddress
+        );
+        const userDomains = await Promise.all(
+          userDomainAddresses.map(async (address) => {
+            const domainName = await performReverseLookup(connection, address);
+            return {
+              name: `${domainName}.sol`,
+              address,
+            };
+          })
+        );
+        userDomains.sort((a, b) => a.name.localeCompare(b.name));
+        setResult(userDomains);
       } catch (err) {
         console.log(`Error fetching user domains ${err}`);
       } finally {
@@ -128,7 +80,7 @@ export const useUserDomains = (
       }
     };
     resolve();
-  }, [address, url]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [userAddress, url]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return [result, loading];
 };


### PR DESCRIPTION
To fetch the `*.sol` domains for a given user we need to:
1. Query for all name service accounts that are owned by the user and set the SOL TLD authority as their parent

To do this, I found a nice tutorial on the solana cookbook that described the layout of a name service account. I then fetched the name service account for one of my *.sol domains and found that its parent was set to the SOL TLD authority and its "class" was set to the default public key. The parent key is encoded in bytes 0-31 and the owner key is encoded in bytes 32-63.

2. Fetch the actual domain name for each of the name service accounts

The domain name is used to derive the address of a name service account but they don't store the name themselves. Since we can't reverse the hash used to derive the address, Bonfida's name service provides a reverse lookup registry that creates entries using the hash of the base58 address of *.sol name service accounts. We can pass the user's name service account addresses to the API in the bonfida SDK to do the reverse lookup and get each of their domain names.

